### PR TITLE
chore: bump pnpm to v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,5 +68,5 @@
     ],
     "dts": true
   },
-  "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800"
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  esbuild: false
+  unrs-resolver: false
+
+minimumReleaseAge: 0


### PR DESCRIPTION
Updates the package manager to pnpm v11.

- Bump `packageManager` to `pnpm@11.9.0`
- Add `pnpm-workspace.yaml` (pnpm 11 moves `allowBuilds` and related settings out of `package.json`)