### PR TITLE
feat: require xo >=4 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dev": "tsdown --watch"
   },
   "peerDependencies": {
-    "xo": ">=3"
+    "xo": ">=4"
   },
   "devDependencies": {
     "@bizon/semantic-release-config": "^3.1.0",


### PR DESCRIPTION
Bumps the `xo` peer dependency from `>=3` to `>=4`. The dev dependency is already on `^4.0.0`.